### PR TITLE
Add ClearReaction command and fix channel name log

### DIFF
--- a/helpers/reactionHandler.ts
+++ b/helpers/reactionHandler.ts
@@ -1,10 +1,20 @@
-import { MessageReaction, User, PartialUser, Emoji } from 'discord.js';
+import {
+    MessageReaction,
+    User,
+    PartialUser,
+    Emoji,
+    TextChannel,
+    DMChannel,
+} from 'discord.js';
 import { client } from '..';
 import { reactions } from './modules';
 
 const react = async (reaction: MessageReaction, user: User | PartialUser) => {
+    const channel = <TextChannel | DMChannel>reaction.message.channel;
     console.log(
-        `${user.tag} reacted with ${reaction.emoji.name} in #${reaction.message.channel.id}`
+        `${user.tag} reacted with ${reaction.emoji.name} in #${
+            'name' in channel ? channel.name : channel.recipient.username
+        }`
     );
     reactions.forEach((command) => {
         let evaluatorOutput = undefined;

--- a/triggers/commands/clearreaction.ts
+++ b/triggers/commands/clearreaction.ts
@@ -1,0 +1,72 @@
+import { MessageEmbed, MessageMentions, TextChannel } from 'discord.js';
+import { client } from '../..';
+import { Command } from '../../Types';
+
+module.exports = <Command>{
+    name: 'clearreaction',
+    description: 'Clear reactions',
+    args: '<emoji/id/name> [from <channel>]',
+    minArgs: 1,
+    guildOnly: true,
+    requiredPerms: 'admin',
+    async execute(message, args) {
+        const channel = <TextChannel>(
+            (args.length > 1
+                ? client.channels.cache.get(
+                      message.content
+                          .match(MessageMentions.CHANNELS_PATTERN)[0]
+                          .slice(2, -1)
+                  )
+                : message.channel)
+        );
+
+        const messages = (await channel.messages.fetch()).filter((message) =>
+            message.reactions.cache.find(
+                (reaction) =>
+                    reaction.emoji.id == args[0] ||
+                    reaction.emoji.name == args[0]
+            )
+                ? true
+                : false
+        );
+
+        let messageCount = 0,
+            reactionCount = 0;
+        messages.forEach((message) => {
+            messageCount++;
+            const reaction = message.reactions.cache.find(
+                (reaction) =>
+                    reaction.emoji.id == args[0] ||
+                    reaction.emoji.name == args[0]
+            );
+            reactionCount += reaction.count;
+            reaction.remove();
+        });
+
+        const myMessage = await message.reply({
+            embed: new MessageEmbed()
+                .setTitle(
+                    `${reactionCount} Reaction${
+                        reactionCount != 1 ? 's' : ''
+                    } Deleted`
+                )
+                .setDescription(
+                    `from ${messageCount} message${
+                        messageCount != 1 ? 's' : ''
+                    }`
+                )
+                .setColor('#4caf50'),
+        });
+        console.log(
+            `Removed ${reactionCount} reaction${
+                reactionCount != 1 ? 's' : ''
+            } from ${messageCount} message${messageCount != 1 ? 's' : ''}`
+        );
+
+        if (channel.id == message.channel.id) {
+            setTimeout(() => {
+                myMessage.delete();
+            }, 5000);
+        }
+    },
+};


### PR DESCRIPTION
Created to clean up a "disruption" from some users spamming reactions in many channels on multiple messages, this allows an easy way to remove a certain reaction from many messages at a time in a channel.
Also finally log the name of the channel, not the ID on reaction.