### PR TITLE
Queue level updates on bot startup

### DIFF
--- a/helpers/modules.ts
+++ b/helpers/modules.ts
@@ -8,12 +8,19 @@ const commandFiles = readdirSync('./triggers/commands').filter((file) =>
     file.endsWith('.ts')
 );
 for (const file of commandFiles) {
-    console.log(`Importing command ${file}`);
-    const command: Command = require(`../triggers/commands/${file}`);
-    commands.set(command.name, command);
-    console.log(`Imported command ${command.name}`);
+    // console.log(`Importing command ${file}`);
+    try {
+        const command: Command = require(`../triggers/commands/${file}`);
+        commands.set(command.name, command);
+        console.log(`Imported command ${command.name}`);
+    } catch (e) {
+        console.warn(
+            `[WARN]\tCould not import command ${file.slice(0, -3)}\n`,
+            e
+        );
+    }
 }
-console.log('Imported commands\n');
+// console.log('Imported commands\n');
 
 export const triggers = new Collection<string, TriggeredCommand>();
 const triggerFiles = readdirSync('./triggers/triggers').filter((file) =>
@@ -21,12 +28,16 @@ const triggerFiles = readdirSync('./triggers/triggers').filter((file) =>
 );
 for (const file of triggerFiles) {
     const name = file.slice(0, -3);
-    console.log(`Importing trigger ${file}`);
-    const trigger: TriggeredCommand = require(`../triggers/triggers/${file}`);
-    triggers.set(name, trigger);
-    console.log(`Imported trigger ${name}`);
+    // console.log(`Importing trigger ${file}`);
+    try {
+        const trigger: TriggeredCommand = require(`../triggers/triggers/${file}`);
+        triggers.set(name, trigger);
+        console.log(`Imported trigger ${name}`);
+    } catch (e) {
+        console.warn(`[WARN]\tCould not import trigger ${name}\n`, e);
+    }
 }
-console.log('Imported triggers\n');
+// console.log('Imported triggers\n');
 
 export const reactions = new Collection<string, ReactionCommand>();
 const reactionFiles = readdirSync('./triggers/reactions').filter((file) =>
@@ -34,9 +45,13 @@ const reactionFiles = readdirSync('./triggers/reactions').filter((file) =>
 );
 for (const file of reactionFiles) {
     const name = file.slice(0, -3);
-    console.log(`Importing reaction command ${file}`);
-    const reaction: ReactionCommand = require(`../triggers/reactions/${file}`);
-    reactions.set(name, reaction);
-    console.log(`Imported reaction command ${name}`);
+    // console.log(`Importing reaction command ${file}`);
+    try {
+        const reaction: ReactionCommand = require(`../triggers/reactions/${file}`);
+        reactions.set(name, reaction);
+        console.log(`Imported reaction command ${name}`);
+    } catch (e) {
+        console.warn(`[WARN]\tCould not import trigger ${name}\n`, e);
+    }
 }
-console.log('Imported reaction commands\n');
+// console.log('Imported reaction commands\n');

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ import { readyMembers, setupMemberListeners } from './helpers/members';
 import { readyVC, setupVCListeners } from './helpers/vc';
 import { setupMessageListeners } from './helpers/messageHandler';
 import { setupReactionListeners } from './helpers/reactionHandler';
+import { queueLevelUpdates } from './util/levels';
 
 client.on('ready', () => {
     console.log(`Logged in as ${client.user.tag}`);
@@ -19,6 +20,8 @@ client.on('ready', () => {
 
     readyMembers();
     readyVC();
+
+    queueLevelUpdates();
 });
 
 setupMessageListeners();

--- a/triggers/commands/levels.ts
+++ b/triggers/commands/levels.ts
@@ -2,7 +2,11 @@ import { EmbedFieldData, MessageEmbed } from 'discord.js';
 import { client, config } from '../..';
 import { Command } from '../../Types';
 import { commandAllowed } from '../../util/commands';
-import { getRankedLeaderboard, redisClient } from '../../util/levels';
+import {
+    getLevelNumber,
+    getRankedLeaderboard,
+    redisClient,
+} from '../../util/levels';
 import { getChannelList, getRandomHexColor } from '../../util/text';
 
 const PAGE_SIZE = 10;
@@ -38,7 +42,7 @@ module.exports = <Command>{
         onPage.forEach((val, index) => {
             const user = client.users.cache.get(val.uid);
             const xp = `${val.data.xp.toLocaleString()} Exp.`.padEnd(14);
-            const level = `Lvl. ${val.data.level}`.padEnd(10);
+            const level = `Lvl. ${getLevelNumber(val.data.xp)}`.padEnd(10);
             const messages = `${val.data.count.toLocaleString()} Message${
                 val.data.count != 1 ? 's' : ''
             }`.padEnd(14);

--- a/util/math.ts
+++ b/util/math.ts
@@ -5,3 +5,8 @@ export function rand(range: number[]) {
         Math.min(...range)
     );
 }
+
+/** Delay async execution. Returns a promise that resolves after a specified time */
+export function delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/util/math.ts
+++ b/util/math.ts
@@ -10,3 +10,10 @@ export function rand(range: number[]) {
 export function delay(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export function coerceBool(value: unknown) {
+    return value ? true : false;
+}
+
+export const ensureSingleInstance = <T>(array: T[]) =>
+    array.filter((value, index) => array.indexOf(value) == index);


### PR DESCRIPTION
To help with transitioning to the new level algorithm (#77), when the bot starts, we should figure out whose levels need to be updated. At the moment, for reasons I can't quite figure out (and is also holding up #23 and by extension #26), we can't update member roles without retrieving the `GuildMember` from a message they've sent. Therefore the bot now just notes whose level roles need to be updated and updates them on their next message.