### PR TITLE
Fix level role undefined

### DIFF
--- a/util/levels.ts
+++ b/util/levels.ts
@@ -108,7 +108,7 @@ export async function getLevelRoleChanges(
     const remove: Role[] = [];
     for await (const snowflakeAndRole of member.roles.cache) {
         const role = snowflakeAndRole[1];
-        if (role.name.startsWith('Level') && role.id != add.id) {
+        if (role.name.startsWith('Level') && role.id != add?.id) {
             remove.push(role);
         }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20424374/111037483-3043b500-83f2-11eb-99ba-4d9225bc8842.png)
If there are no roles below a member's level, add will be undefined and add.id will throw a TypeError.