### PR TITLE
Fix text cut issue and change to clean install

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -22,7 +22,7 @@ while ($true) {
         Write-Output "Saving commit to file"
         Out-File -FilePath $COMMITFILE -InputObject $LATEST_COMMIT
         if (@(git diff-tree --no-commit-id --name-only -r $LATEST_COMMIT) -contains "package.json") {
-            npm install
+            npm ci
         }
     } else {
         break;

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ while true; do # Loop forever
         fi
         # Attempt to update dependencies
         COMMITFILE=./.commit
-        LATESTCOMMIT=`git show | grep commit | cut -c8-14`
+        LATESTCOMMIT=`git show | grep "commit " | cut -c8-14`
         echo "Last commit:  " `cat $COMMITFILE`
         echo "Latest commit: $LATESTCOMMIT"
         if [ -f "$COMMITFILE" ] && [ `cat $COMMITFILE` == "$LATESTCOMMIT" ]; then  # We're up to date
@@ -18,7 +18,7 @@ while true; do # Loop forever
             # If package.json was modified
             if git diff-tree --no-commit-id --name-only -r $LATESTCOMMIT | grep package.json
             then
-                npm install # Install updated/new dependencies
+                npm ci # Install updated/new dependencies
             fi
         fi
     else


### PR DESCRIPTION
Grep was returning two lines when it should have only returned one, and when updating, a clean install should be run so it doesn't write to package-lock, which can cause problems when pulling